### PR TITLE
Get the codebase back to building and running successfully.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # override to push to a different registry or tag the image differently
-CONTAINER_REGISTRY ?= gcr.io/tetratelabs
-CONTAINER_TAG ?= v0.1
+REGISTRY ?= gcr.io/tetratelabs
+TAG ?= v0.1
 
 # Make sure we pick up any local overrides.
 -include .makerc

--- a/pkg/cloudmap/watcher.go
+++ b/pkg/cloudmap/watcher.go
@@ -23,10 +23,21 @@ import (
 var serviceFilterNamespaceID = servicediscovery.ServiceFilterNameNamespaceId
 var filterConditionEquals = servicediscovery.FilterConditionEq
 
+// Use an empty string as the token for long-lived credentials (token only needed if using STS)
+// https://pkg.go.dev/github.com/aws/aws-sdk-go/aws/credentials?tab=doc#NewStaticCredentials
+const emptyToken = ""
+
 // NewWatcher returns a Cloud Map watcher
-func NewWatcher(store Store, region string) (*Watcher, error) {
+func NewWatcher(store Store, region, id, secret string) (*Watcher, error) {
+	var creds *credentials.Credentials
+	if len(id) == 0 || len(secret) == 0 {
+		creds = credentials.NewEnvCredentials()
+	} else {
+		creds = credentials.NewStaticCredentials(id, secret, emptyToken)
+	}
+
 	session, err := session.NewSession(&aws.Config{
-		Credentials: credentials.NewEnvCredentials(),
+		Credentials: creds,
 		Region:      aws.String(region),
 	})
 	if err != nil {


### PR DESCRIPTION
As of this commit the codebase is back in running order; it'll deploy in k8s and connects to cloud map fine. I haven't verified it processes that data correctly yet since cloud map doesn't populate data from EKS automatically. I'm figuring out how to make that happen and will update the readme afterwards in a follow-on PR. This commit also restores the AWS_REGION environment variable - now you can fully specify all of the AWS data via environment variables OR flags.