### PR TITLE
Get everything working e2e against real Cloud Map data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .idea
-vendor
+/vendor
 docker/istio-cloud-map-static
 .makerc
-main
-istio-cloud-map
+/main
+/istio-cloud-map

--- a/cmd/istio-cloud-map/main.go
+++ b/cmd/istio-cloud-map/main.go
@@ -130,7 +130,8 @@ func serve() (serve *cobra.Command) {
 	serve.PersistentFlags().StringVar(&namespace, "namespace", "",
 		"If provided, the namespace this operator publishes CRDs to. If no value is provided it will be populated from the WATCH_NAMESPACE environment variable.")
 
-	serve.PersistentFlags().StringVar(&awsRegion, "aws-region", "", "AWS Region to connect to Cloud Map in")
+	serve.PersistentFlags().StringVar(&awsRegion, "aws-region", "",
+		"AWS Region to connect to Cloud Map. Use this OR the environment variable AWS_REGION.")
 	serve.PersistentFlags().StringVar(&awsID, "aws-access-key-id", "",
 		"AWS Key ID to use to connect to Cloud Map. Use flags for both this and aws-secret OR use "+
 			"the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. Flags and env vars cannot be mixed.")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/aws/aws-sdk-go v1.30.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.3.2
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/kubernetes/aws-config.yaml
+++ b/kubernetes/aws-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-config
+data:
+  aws-region: us-east-2

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-cloud-map-operator
-  namespace: istio-system
   labels:
     app: istio-cloud-map
 spec:
@@ -42,11 +41,3 @@ spec:
             secretKeyRef:
               key: secret-access-key
               name: aws-credz
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: aws-config
-  namespace: istio-system
-data:
-  aws-region: us-west-2

--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -18,7 +18,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-cloud-map-service-account
-  namespace: istio-system
   labels:
     app: istio-cloud-map
 ---
@@ -35,4 +34,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istio-cloud-map-service-account
-    namespace: istio-system

--- a/pkg/control/mock/serviceentry.go
+++ b/pkg/control/mock/serviceentry.go
@@ -32,6 +32,10 @@ func (s *SEStore) Insert(se *v1alpha3.ServiceEntry) error {
 	return nil
 }
 
+func (s *SEStore) Update(_, _ *v1alpha3.ServiceEntry) error {
+	return nil
+}
+
 // Delete is not implemented
 func (s *SEStore) Delete(se *v1alpha3.ServiceEntry) error {
 	return nil

--- a/pkg/control/synchronizer.go
+++ b/pkg/control/synchronizer.go
@@ -84,7 +84,7 @@ func (s *synchronizer) createOrUpdate(host string, endpoints []*v1alpha3.Service
 	// Otherwise, create a new Service Entry
 	rv, err := s.client.Create(newServiceEntry)
 	if err != nil {
-		log.Printf("error creating Service Entry %q: %v", infer.ServiceEntryName(host), err)
+		log.Printf("error creating Service Entry %q: %v\n%v", infer.ServiceEntryName(host), err, newServiceEntry)
 	}
 	log.Printf("created Service Entry %q, ResourceVersion is %q", infer.ServiceEntryName(host), rv.ResourceVersion)
 }

--- a/pkg/infer/infer.go
+++ b/pkg/infer/infer.go
@@ -11,7 +11,6 @@ import (
 )
 
 // ServiceEntry infers an Istio service entry based on provided information
-// TODO: Namespaces...
 func ServiceEntry(owner v1.OwnerReference, host string, endpoints []*v1alpha3.ServiceEntry_Endpoint) *ic.ServiceEntry {
 	addresses := []string{}
 	if len(endpoints) > 0 {

--- a/pkg/serviceentry/handler.go
+++ b/pkg/serviceentry/handler.go
@@ -38,10 +38,7 @@ func (c handler) OnAdd(obj interface{}) {
 func (c handler) OnUpdate(oldObj, newObj interface{}) {
 	old := oldObj.(*v1alpha3.ServiceEntry)
 	se := newObj.(*v1alpha3.ServiceEntry)
-
-	// order matters here, since it's likely these work on the same set of hosts: delete the old first, then add the new
-	c.Delete(old)
-	c.Insert(se)
+	c.Update(old, se)
 }
 
 func (c handler) OnDelete(obj interface{}) {


### PR DESCRIPTION
Tested now against Cloud Map with some sample data. Fixes include:
- Publishes ServiceEntries into the namespace from the `namespace` flag, or it's own namespace (or the default namespace if it can't determine it's own namespace)
- Populates OwnerReferences correctly
- Got parity between environment variables and flags for AWS for configuring access key, secret, and region
- Fixed .gitignore to ignore the correct files (and not ignore `cmd/istio-cloud-map`)

I need to go back and add a bit better test coverage over some of the new code.